### PR TITLE
Docker environment variables in Jenkins only set if TLS variable is set to true

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ Additional environment variables that allow fine tune Jenkins runtime configurat
 * NODEJS_PACKAGES_REFRESH_HOURS, nodejs package refresh time in hours.
 * GIT_GLOBAL_CONFIG_NAME, Git global config name
 * GIT_GLOBAL_CONFIG_EMAIL, Git global config email
+* AWS_DEFAULT_REGION, set the AWS default region for the CLI at a global level
+* DOCKER_TLS_VERIFY, Docker CLI variable to declare a TLS-enabled engine
+* DOCKER_HOST, Docker CLI variable to declare the endpoint to target
+* DOCKER_CERT_PATH, Docker CLI variable to declare the path to the certificate
+* DOCKER_NETWORK_NAME, the Docker custom network to launch containers on
 
 ## Run docker-jenkins with OpenLDAP
 The following assumes that MySQL and OpenLDAP are running.

--- a/resources/init.groovy.d/adop_general.groovy
+++ b/resources/init.groovy.d/adop_general.groovy
@@ -52,6 +52,8 @@ Thread.start {
     // Set Docker environment
     if ( dockerTLSVerify != null && dockerTLSVerify.toBoolean()) {
         envVars.put("DOCKER_TLS_VERIFY", env['DOCKER_TLS_VERIFY'])
+    } else {
+        envVars.remove("DOCKER_TLS_VERIFY")
     }
     if ( dockerHost != null ) {
         envVars.put("DOCKER_HOST", dockerHost)

--- a/resources/init.groovy.d/adop_general.groovy
+++ b/resources/init.groovy.d/adop_general.groovy
@@ -11,6 +11,8 @@ def gitGlobalConfigName = env['GIT_GLOBAL_CONFIG_NAME']
 def gitGlobalConfigEmail = env['GIT_GLOBAL_CONFIG_EMAIL']
 def awsDefaultRegion = env['AWS_DEFAULT_REGION']
 def dockerTLSVerify = env['DOCKER_TLS_VERIFY']
+def dockerHost = env['DOCKER_HOST']
+def dockerCertPath = env['DOCKER_CLIENT_CERT_PATH']
 def dockerNetworkName = env['DOCKER_NETWORK_NAME']
 
 // Constants
@@ -50,9 +52,15 @@ Thread.start {
     // Set Docker environment
     if ( dockerTLSVerify != null && dockerTLSVerify.toBoolean()) {
         envVars.put("DOCKER_TLS_VERIFY", env['DOCKER_TLS_VERIFY'])
-        envVars.put("DOCKER_HOST", env['DOCKER_HOST'])
-        envVars.put("DOCKER_CERT_PATH", env['DOCKER_CLIENT_CERT_PATH'])
-	envVars.put("DOCKER_NETWORK_NAME", env['DOCKER_NETWORK_NAME'])
+    }
+    if ( dockerHost != null ) {
+        envVars.put("DOCKER_HOST", dockerHost)
+    }
+    if ( dockerCertPath != null ) {
+        envVars.put("DOCKER_CERT_PATH", dockerCertPath)
+    }
+    if ( dockerNetworkName != null ) {
+        envVars.put("DOCKER_NETWORK_NAME", dockerNetworkName)
     }
 
     // Jenkins SSH Credentials


### PR DESCRIPTION
There are a handful of Docker environment variables that are passed through to Jenkins so that it can talk to the underlying Engine that were only being set if DOCKER_TLS_VERIFY was set to 1. This meant that Jenkins was not correctly configured and the Java cartridge would not run if using an Engine (or Swarm) that was not TLS-enabled without manually setting the environment variables. Also added logic to remove DOCKER_TLS_VERIFY from Jenkins if not set to true, because the Docker client helpfully doesn't acknowledge any other value (like, for example, it being set to 0).