### PR TITLE
Changed owner of userContent directory to Jenkins

### DIFF
--- a/resources/scripts/generate_key.sh
+++ b/resources/scripts/generate_key.sh
@@ -57,6 +57,9 @@ if [[ ! $(ls -A "${JENKINS_SSH_DIR}") ]]; then
   mkdir -p ${JENKINS_USER_CONTENT_DIR}
   rm -f ${JENKINS_USER_CONTENT_DIR}/id_rsa.pub
   cp ${JENKINS_SSH_DIR}/id_rsa.pub ${JENKINS_USER_CONTENT_DIR}/id_rsa.pub
+
+  # Set correct permissions for Content Directory
+  chown 1000:1000 "${JENKINS_USER_CONTENT_DIR}"
 fi
 # public_key_val=$(cat ${JENKINS_SSH_DIR}/id_rsa.pub)
 


### PR DESCRIPTION
This is required in order for jenkins to be able to place files that should be publicly accessible in that folder.