### PR TITLE
Adding default script approval for java string methods in workflow job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ COPY resources/scriptler/ /usr/share/jenkins/ref/scriptler/scripts/
 COPY resources/views/ /usr/share/jenkins/ref/init.groovy.d/
 COPY resources/m2/ /usr/share/jenkins/ref/.m2
 COPY resources/entrypoint.sh /entrypoint.sh
+COPY resources/scriptApproval.xml /usr/share/jenkins/ref/
 
 # Reprotect
 USER root

--- a/resources/scriptApproval.xml
+++ b/resources/scriptApproval.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<scriptApproval plugin="script-security@1.17">
+  <approvedScriptHashes/>
+  <approvedSignatures>
+    <string>field java.util.ArrayList size</string>
+    <string>method groovy.lang.GString plus java.lang.String</string>
+  </approvedSignatures>
+  <aclApprovedSignatures/>
+  <approvedClasspathEntries/>
+  <pendingScripts/>
+  <pendingSignatures/>
+  <pendingClasspathEntries/>
+</scriptApproval>


### PR DESCRIPTION
Workflow job to load in cartridge collections uses some standard Java methods to read list sizes and strings. Added an xml which adds permissions to use these methods using the script approval plugin. File is copied to the jenkins home directory.