### PR TITLE
Adding an extra variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN chmod +x -R /usr/share/jenkins/ref/adop_scripts/ && chmod +x /entrypoint.sh
 # Environment variables
 ENV ADOP_LDAP_ENABLED=true ADOP_SONAR_ENABLED=true ADOP_ANT_ENABLED=true ADOP_MAVEN_ENABLED=true ADOP_NODEJS_ENABLED=true ADOP_GERRIT_ENABLED=true
 
+ENV LDAP_GROUP_NAME_ADMIN=""
+
 RUN /usr/local/bin/plugins.sh /usr/share/jenkins/ref/plugins.txt
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Additional environment variables that allow fine tune Jenkins runtime configurat
 * LDAP_DISPLAY_NAME_ATTRIBUTE_NAME, LDAP object field used as a display name
 * LDAP_DISABLE_MAIL_ADDRESS_RESOLVER, flag indicating if the email address resolver should be disabled
 * LDAP_MAIL_ADDRESS_ATTRIBUTE_NAME, LDAP object field used as a email address
+* LDAP_GROUP_NAME_ADMIN, LDAP admin group. Default to administrators.
 * SONAR_SERVER_URL, the sonar server URL
 * SONAR_ACCOUNT_LOGIN, username to use when connecting to sonar
 * SONAR_ACCOUNT_PASSWORD, password to use when connecting to sonar

--- a/resources/init.groovy.d/role_based_auth.groovy
+++ b/resources/init.groovy.d/role_based_auth.groovy
@@ -7,10 +7,12 @@ import java.util.*
 import com.michelin.cio.hudson.plugins.rolestrategy.*
 import java.lang.reflect.*
 
+def env = System.getenv()
+
 // Roles
 def globalRoleRead = "read"
 def globalRoleAdmin = "admin"
-def ldapGroupNameAdmin = "administrators"
+def ldapGroupNameAdmin = env['LDAP_GROUP_NAME_ADMIN'] ?: "administrators"
 
 def jenkinsInstance = Jenkins.getInstance()
 def currentAuthenticationStrategy = Hudson.instance.getAuthorizationStrategy()


### PR DESCRIPTION
Hi Nick,

I am adding LDAP_GROUP_NAME_ADMIN to specify the admin group in LDAP. If the variable is not provided it defaults to "administrators". This change is required for running ADOP on premises with non-adop LDAP.
The modification made has been tested and Jenkins is running without any issues. You can find a built image here: https://hub.docker.com/r/mihailivanov/adop-jenkins/tags/

Thanks,
Mihail