### PR TITLE
Feature: Added a groovy script for Configuring SMTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Runtime configuration can be provided using environment variables:
 * ADOP_MAVEN_ENABLED, allow enable/disable Jenkins-MAVEN integration. Default to true (enabled).
 * ADOP_NODEJS_ENABLED, allow enable/disable Jenkins-NODEJS integration. Default to true (enabled).
 * ADOP_GERRIT_ENABLED, allow enable/disable Jenkins-GERRIT integration. Default to true (enabled).
+* ADOP_SMTP_ENABLED, allow enable/disable Jenkins-SMTP integration. Default to false (disabled).
 
 Additional environment variables that allow fine tune Jenkins runtime configuration are:
 
@@ -69,6 +70,11 @@ Additional environment variables that allow fine tune Jenkins runtime configurat
 * DOCKER_HOST, Docker CLI variable to declare the endpoint to target
 * DOCKER_CERT_PATH, Docker CLI variable to declare the path to the certificate
 * DOCKER_NETWORK_NAME, the Docker custom network to launch containers on
+* SMTP_HOST, SMTP server e.g smtp.gmail.com
+* SMTP_PORT, SMTP server port
+* SMTP_USER, SMTP user
+* SMTP_PASSWORD, SMTP password
+* SMTP_SYSAD_EMAIL, same with SMTP user
 
 ## Run adop-jenkins with OpenLDAP
 The following assumes that MySQL and OpenLDAP are running.

--- a/resources/init.groovy.d/smtp.groovy
+++ b/resources/init.groovy.d/smtp.groovy
@@ -1,0 +1,51 @@
+import hudson.model.*;
+import jenkins.model.*;
+import hudson.tools.*;
+import hudson.util.Secret;
+
+// Check if enabled
+def env = System.getenv()
+if (!env['ADOP_SMTP_ENABLED'].toBoolean()) {
+    println "--> SMTP configuration is disabled."
+    return
+}
+
+// Variables
+def SystemAdminMailAddress = env['SMTP_SYSAD_EMAIL']
+def SMTPUser = env['SMTP_USER']
+def SMTPPassword = env['SMTP_PASSWORD']
+def SMTPPort = env['SMTP_PORT']
+def SMTPHost = env['SMTP_HOST']
+
+// Constants
+def instance = Jenkins.getInstance()
+def mailServer = instance.getDescriptor("hudson.tasks.Mailer")
+def jenkinsLocationConfiguration = JenkinsLocationConfiguration.get()
+def extmailServer = instance.getDescriptor("hudson.plugins.emailext.ExtendedEmailPublisher")
+
+Thread.start {
+    sleep 10000
+
+        //Jenkins Location
+        println "--> Configuring JenkinsLocation"
+        jenkinsLocationConfiguration.setAdminAddress(SystemAdminMailAddress)
+        jenkinsLocationConfiguration.save()
+
+        //E-mail Server
+        mailServer.setSmtpAuth(SMTPUser, SMTPPassword)
+        mailServer.setSmtpHost(SMTPHost)
+        mailServer.setSmtpPort(SMTPPort)
+        mailServer.setCharset("UTF-8")
+
+        //Extended-Email
+        extmailServer.smtpAuthUsername=SMTPUser
+        extmailServer.smtpAuthPassword=Secret.fromString(SMTPPassword)
+        extmailServer.smtpHost=SMTPHost
+        extmailServer.smtpPort=SMTPPort
+        extmailServer.charset="UTF-8"
+        extmailServer.defaultSubject="\$PROJECT_NAME - Build # \$BUILD_NUMBER - \$BUILD_STATUS!"
+        extmailServer.defaultBody="\$PROJECT_NAME - Build # \$BUILD_NUMBER - \$BUILD_STATUS:\n\nCheck console output at \$BUILD_URL to view the results."
+
+    // Save the state
+    instance.save()
+}


### PR DESCRIPTION
@nickdgriffin @anton-kasperovich 

Contributing the groovy script that we are currently using in our project. It configures the SMTP settings for Extended Email and Mail Server in "Manage Jenkins".

Example required variables:

ADOP_SMTP_ENABLED=true
SMTP_SYSAD_EMAIL=john.smith@gmail.com
SMTP_USER=john.smith@gmail.com
SMTP_PASSWORD=password123
SMTP_PORT=25
SMTP_HOST=smtp.gmail.com

@WYarde this is our pull request.

Works well with a Mail Server container - See Pull request - https://github.com/Accenture/adop-docker-compose/pull/111
