### PR TITLE
Refactor adop-maven installation to allow multiple versions of maven …

### DIFF
--- a/resources/init.groovy.d/adop_maven.groovy
+++ b/resources/init.groovy.d/adop_maven.groovy
@@ -12,7 +12,13 @@ if (!env['ADOP_MAVEN_ENABLED'].toBoolean()) {
 }
 
 // Variables
+// MAVEN_VERSION can be defined as a single version or a comma separated string of versions
+// eg. 
+// MAVEN_VERSION=3.0.5
+// MAVEN_VERSION=3.0.5,3.2.5
+
 def maven_version = env['MAVEN_VERSION']
+def maven_version_list = maven_version.split(',')
 
 // Constants
 def instance = Jenkins.getInstance()
@@ -23,31 +29,44 @@ Thread.start {
     // Maven
     println "--> Configuring Maven"
     def desc_MavenTool = instance.getDescriptor("hudson.tasks.Maven")
-
-    def mavenInstaller = new MavenInstaller(maven_version)
-    def installSourceProperty = new InstallSourceProperty([mavenInstaller])
-    def maven_inst = new MavenInstallation(
-      "ADOP Maven", // Name
-      "", // Home
-      [installSourceProperty]
-    )
-
-    // Only add ADOP Maven if it does not exist - do not overwrite existing config
     def maven_installations = desc_MavenTool.getInstallations()
-    def maven_inst_exists = false
-    maven_installations.each {
-      installation = (MavenInstallation) it
-        if ( maven_inst.getName() ==  installation.getName() ) {
-                maven_inst_exists = true
-                println("Found existing installation: " + installation.getName())
+
+    maven_version_list.eachWithIndex { version, index ->
+        def mavenInstaller = new MavenInstaller(version)
+        def installSourceProperty = new InstallSourceProperty([mavenInstaller])
+        
+        def name="ADOP Maven_" + version
+
+        // This makes the solution backwards-compatible, and will treat the first version in the array as "ADOP Maven"
+        if (index == 0)
+        {
+            name="ADOP Maven"
+        }
+
+        def maven_inst = new MavenInstallation(
+          name, // Name
+          "", // Home
+          [installSourceProperty]
+        )
+
+        // Only add a Maven installation if it does not already exist - do not overwrite existing config
+        
+        def maven_inst_exists = false
+        maven_installations.each {
+          installation = (MavenInstallation) it
+            if ( maven_inst.getName() ==  installation.getName() ) {
+                    maven_inst_exists = true
+                    println("Found existing installation: " + installation.getName())
+            }
+        }
+        
+        if (!maven_inst_exists) {
+            maven_installations += maven_inst
         }
     }
-    
-    if (!maven_inst_exists) {
-        maven_installations += maven_inst
-        desc_MavenTool.setInstallations((MavenInstallation[]) maven_installations)
-        desc_MavenTool.save()
-    }
+
+    desc_MavenTool.setInstallations((MavenInstallation[]) maven_installations)
+    desc_MavenTool.save()
 
     // Save the state
     instance.save()


### PR DESCRIPTION
…to be installed

MAVEN_VERSION variable can now be a comma separated list of versions to be installed. 

If multiple versions are specified, the first in the list will be named 'ADOP Maven' for backwards compatibility. Any additional installations will be named 'ADOP Maven_$VERSION'.

If an existing installation is found in Jenkins with the same name it will not be overwritten. This is the same functionality as before. 

Tests performed:
Loaded with: MAVEN_VERSION='3.0.5'
Maven installations: ADOP Maven

Loaded with: MAVEN_VERSION='3.0.5,3.2.5'
Maven installations: ADOP Maven, ADOP Maven_3.2.5

Loaded with: MAVEN_VERSION=''
Maven installations: (unchanged after loading)