### PR TITLE
Adding all the core jenkins items required for pluggable scm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ MAINTAINER Nick Griffin, <nicholas.griffin>
 
 ENV GERRIT_HOST_NAME gerrit
 ENV GERRIT_PORT 8080
-ENV GERRIT_JENKINS_USERNAME="" GERRIT_JENKINS_PASSWORD=""
+ENV GERRIT_SSH_PORT 29418
+ENV GERRIT_PROFILE="ADOP Gerrit" GERRIT_JENKINS_USERNAME="" GERRIT_JENKINS_PASSWORD=""
 
 
 # Copy in configuration files
@@ -27,6 +28,8 @@ RUN chmod +x -R /usr/share/jenkins/ref/adop_scripts/ && chmod +x /entrypoint.sh
 ENV ADOP_LDAP_ENABLED=true ADOP_SONAR_ENABLED=true ADOP_ANT_ENABLED=true ADOP_MAVEN_ENABLED=true ADOP_NODEJS_ENABLED=true ADOP_GERRIT_ENABLED=true
 ENV LDAP_GROUP_NAME_ADMIN=""
 ENV JENKINS_OPTS="--prefix=/jenkins -Djenkins.install.runSetupWizard=false"
+ENV PLUGGABLE_SCM_PROVIDER_PROPERTIES_PATH="/var/jenkins_home/userContent/datastore/pluggable/scm"
+ENV PLUGGABLE_SCM_PROVIDER_PATH="/var/jenkins_home/userContent/job_dsl_additional_classpath/"
 
 RUN /usr/local/bin/plugins.sh /usr/share/jenkins/ref/plugins.txt
 

--- a/resources/entrypoint.sh
+++ b/resources/entrypoint.sh
@@ -3,9 +3,19 @@
 echo "Genarate JENKINS SSH KEY and add it to gerrit"
 host=$GERRIT_HOST_NAME
 port=$GERRIT_PORT
+gerrit_provider_id="adop-gerrit"
+gerrit_protocol="ssh"
 username=$GERRIT_JENKINS_USERNAME
 password=$GERRIT_JENKINS_PASSWORD
 nohup /usr/share/jenkins/ref/adop\_scripts/generate_key.sh -c ${host} -p ${port} -u ${username} -w ${password} &
+
+echo "Setting up your default SCM provider - Gerrit..."
+mkdir -p $PLUGGABLE_SCM_PROVIDER_PROPERTIES_PATH $PLUGGABLE_SCM_PROVIDER_PATH
+mkdir -p ${PLUGGABLE_SCM_PROVIDER_PROPERTIES_PATH}/CartridgeLoader ${PLUGGABLE_SCM_PROVIDER_PROPERTIES_PATH}/ScmProviders
+nohup /usr/share/jenkins/ref/adop\_scripts/generate_gerrit_scm.sh -i ${gerrit_provider_id} -p ${gerrit_protocol} -h ${host} &
+
+echo "Tokenising scriptler scripts..."
+sed -i "s,###SCM_PROVIDER_PROPERTIES_PATH###,$PLUGGABLE_SCM_PROVIDER_PROPERTIES_PATH,g" /usr/share/jenkins/ref/scriptler/scripts/retrieve_scm_props.groovy
 
 echo "skip upgrade wizard step after installation"
 echo "2.7.4" > /var/jenkins_home/jenkins.install.UpgradeWizard.state

--- a/resources/init.groovy.d/adop_gerrit.groovy
+++ b/resources/init.groovy.d/adop_gerrit.groovy
@@ -17,6 +17,7 @@ def gerrit_front_end_url = env['GERRIT_FRONT_END_URL']
 def gerrit_ssh_port = env['GERRIT_SSH_PORT'] ?: "29418"
 gerrit_ssh_port = gerrit_ssh_port.toInteger()
 def gerrit_username = env['GERRIT_USERNAME'] ?: "jenkins"
+def gerrit_profile = env['GERRIT_PROFILE'] ?: "ADOP Gerrit"
 def gerrit_email = env['GERRIT_EMAIL'] ?: ""
 def gerrit_ssh_key_file = env['GERRIT_SSH_KEY_FILE'] ?: "/var/jenkins_home/.ssh/id_rsa"
 def gerrit_ssh_key_password = env['GERRIT_SSH_KEY_PASSWORD'] ?: null
@@ -32,7 +33,7 @@ Thread.start {
 
     def gerrit_trigger_plugin = PluginImpl.getInstance()
 
-    def gerrit_server = new GerritServer("ADOP Gerrit")
+    def gerrit_server = new GerritServer(gerrit_profile)
 
     def gerrit_servers = gerrit_trigger_plugin.getServerNames()
     def gerrit_server_exists = false

--- a/resources/plugins.txt
+++ b/resources/plugins.txt
@@ -125,3 +125,4 @@ workflow-remote-loader:1.3
 workflow-cps-global-lib:2.3
 workflow-durable-task-step:2.5
 dependency-check-jenkins-plugin:1.4.3
+uno-choice:1.5.2

--- a/resources/scriptler/retrieve_scm_props.groovy
+++ b/resources/scriptler/retrieve_scm_props.groovy
@@ -1,0 +1,31 @@
+import hudson.model.*;
+import hudson.util.*;
+
+base_path = "###SCM_PROVIDER_PROPERTIES_PATH###"
+
+// Initialise folder containing all SCM provider properties files
+String PropertiesPath = base_path + "/ScmProviders/"
+File folder = new File(PropertiesPath)
+def providerList = []
+
+// Loop through all files in properties data store and add to returned list
+for (File fileEntry : folder.listFiles()) {
+  if (!fileEntry.isDirectory()){
+    String title = PropertiesPath +  fileEntry.getName()
+    Properties scmProperties = new Properties()
+    InputStream input = null
+    input = new FileInputStream(title)
+    scmProperties.load(input)
+    String url = scmProperties.getProperty("scm.url")
+    String protocol = scmProperties.getProperty("scm.protocol")
+    String id = scmProperties.getProperty("scm.id")
+    String output = url + " - " + protocol + " (" + id + ")"
+    providerList.add(output)
+  }
+}
+
+if (providerList.isEmpty()) {
+    providerList.add("No SCM providers found")
+}
+
+return providerList;

--- a/resources/scripts/generate_gerrit_scm.sh
+++ b/resources/scripts/generate_gerrit_scm.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+set -e
+
+# Usage
+usage() {
+    echo "Usage:"
+    echo "    ${0} -i <loader_id> -p <protocol> -h <host>"
+    exit 1
+}
+
+# Constants
+SCM_TYPE="gerrit"
+LOADER_PATH="${PLUGGABLE_SCM_PROVIDER_PROPERTIES_PATH}/CartridgeLoader"
+SCM_PROVIDERS_PATH="${PLUGGABLE_SCM_PROVIDER_PROPERTIES_PATH}/ScmProviders"
+GERRIT_SSH_USER=$GERRIT_JENKINS_USERNAME
+GERRIT_PERMISSIONS_PATH='${PROJECT_NAME}/permissions'
+GERRIT_URL=$(echo ${ROOT_URL} | sed "s/jenkins/${GERRIT_HOST_NAME}/g")
+
+while getopts "i:p:h:" opt; do
+  case $opt in
+    i)
+      loader_id=${OPTARG}
+      ;;
+    p)
+      protocol=${OPTARG}
+      ;;
+    h)
+      host=${OPTARG}
+      ;;
+    *)
+      echo "Invalid parameter(s) or option(s)."
+      usage
+      ;;
+  esac
+done
+
+if [ -z "${loader_id}" ] || [ -z "${protocol}" ] || [ -z "${host}" ]; then
+    echo "Parameters missing"
+    usage
+fi
+
+# Setup Cartridge loader properties
+LOADER_FILE=$LOADER_PATH/${loader_id}.props
+touch $LOADER_FILE
+cat > $LOADER_FILE <<EOF
+loader.id=${loader_id}
+gerrit.endpoint=${host}
+gerrit.user=${GERRIT_SSH_USER}
+gerrit.port=${GERRIT_SSH_PORT}
+gerrit.protocol=ssh
+gerrit.permissions.path=${GERRIT_PERMISSIONS_PATH}
+gerrit.permissions.with_review.path=${GERRIT_PERMISSIONS_PATH}-with-review
+EOF
+
+# Setup SCM Provider properties
+GERRIT_PROVIDER_ID=${loader_id}-{protocol}
+case $protocol in
+ssh)
+  PROPS_FILE=${SCM_PROVIDERS_PATH}/${loader_id}-${protocol}.props
+  touch $PROPS_FILE
+
+cat > $PROPS_FILE <<EOF
+scm.loader.id=${loader_id}
+scm.id=${loader_id}-ssh
+scm.type=${SCM_TYPE}
+scm.code_review.enabled=true
+scm.protocol=ssh
+scm.port=${GERRIT_SSH_PORT}
+scm.host=${host}
+scm.url=${GERRIT_URL}
+
+scm.gerrit.server.profile=${GERRIT_PROFILE}
+scm.gerrit.ssh.clone.user=${GERRIT_SSH_USER}
+EOF
+  ;;
+http)
+  PROPS_FILE=${SCM_PROVIDERS_PATH}/${loader_id}-${protocol}.props
+  touch $PROPS_FILE
+
+  cat > $PROPS_FILE <<EOF
+scm.loader.id=${loader_id}
+scm.id=${loader_id}-http
+scm.type=${SCM_TYPE}
+scm.code_review.enabled=true
+scm.protocol=http
+scm.port=${GERRIT_PORT}
+scm.host=${host}
+scm.url=${GERRIT_URL}
+
+scm.gerrit.server.profile=${GERRIT_PROFILE}
+EOF
+  ;;
+*)
+  echo "Invalid protocol: Must use http or ssh"
+  usage
+  ;;
+esac
+


### PR DESCRIPTION
The changes that are included in this pull request include:
* New environment variables required for setting up the Gerrit scm provider as well as default filepaths
* Helper script to generate your default properties files for the Gerrit SCM provider
* Property files for gerrit ssh SCM provider
* Jenkins private as a secret file credential
* Active Choices plugin
* Scriptler script to retrieve your SCM properties files in a nice format (required by Load_Cartridge)