### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Supported tags and respective `Dockerfile` links
 
+- [`0.2.2`, `0.2.2` (*0.2.2/Dockerfile*)](https://github.com/Accenture/adop-jenkins/blob/0.2.2/Dockerfile)
 - [`0.2.0`, `0.2.0` (*0.2.0/Dockerfile*)](https://github.com/Accenture/adop-jenkins/blob/0.2.0/Dockerfile)
 
 # What is adop-jenkins?


### PR DESCRIPTION
Referencing latest 0.2.2 release

I assume this automatically pulls through to https://hub.docker.com/r/accenture/adop-jenkins/  if not, same change is needed there.