### PR TITLE
Add groovy installation profile configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Additional environment variables that allow fine tune Jenkins runtime configurat
 * DOCKER_HOST, Docker CLI variable to declare the endpoint to target
 * DOCKER_CERT_PATH, Docker CLI variable to declare the path to the certificate
 * DOCKER_NETWORK_NAME, the Docker custom network to launch containers on
+* GROOVY_VERSION, a comma delimited list of Groovy installation profiles to install (e.g. 2.4.8, 2.4.3).
 
 ## Run adop-jenkins with OpenLDAP
 The following assumes that MySQL and OpenLDAP are running.

--- a/resources/init.groovy.d/adop_groovy.groovy
+++ b/resources/init.groovy.d/adop_groovy.groovy
@@ -1,0 +1,53 @@
+import hudson.model.*;
+import jenkins.model.*;
+import hudson.tools.*;
+import hudson.plugins.groovy.*;
+
+def env = System.getenv();
+def groovyVersion = env['GROOVY_VERSION']
+def groovyVersionList = groovyVersion.split(',')
+
+def instance = Jenkins.getInstance()
+
+Thread.start {
+ sleep 10000
+
+ println "--> Configuring Groovy"
+ def groovyDescriptor = instance.getDescriptor("hudson.plugins.groovy.GroovyInstallation")
+ def groovyInstallations = groovyDescriptor.getInstallations()
+
+ groovyVersionList.eachWithIndex {
+  version,
+  index ->
+  def installer = new GroovyInstaller(version)
+  def installSourceProperty = new InstallSourceProperty([installer])
+
+  def name = "ADOP Groovy_" + version
+
+  if (index == 0) {
+   name = "ADOP Groovy"
+  }
+
+  def installation = new GroovyInstallation(
+   name,
+   "", [installSourceProperty]
+  )
+
+  def groovyIntExists = false
+  groovyInstallations.each {
+   currentInstallation = (GroovyInstallation) it
+   if (installation.getName() == currentInstallation.getName()) {
+    groovyIntExists = true
+    println("Found existing installation: " + installation.getName())
+   }
+  }
+
+  if (!groovyIntExists) {
+   groovyInstallations += installation
+  }
+ }
+
+ groovyDescriptor.setInstallations((GroovyInstallation[]) groovyInstallations)
+
+ instance.save()
+}


### PR DESCRIPTION
**As** a developer,
**I want** a groovy installation profile to be configurable via environment variables
**So** that I don't have to manually configure the Groovy profile. 

**Scenario:** Test with env variable GROOVY_VERSION='2.4.3'
**Expected:**
ADOP groovy profile with version 2.4.3 to exist.

**Scenario:** Test with env variables GROOVY_VERSION='2.4.3,2.4.8'
**Expected:** 
The following profiles to be installed:
* ADOP Groovy_2.4.3
* ADOP Groovy_2.4.8

The installation is inspired from the maven setup in which the GROOVY_VERSION env variables takes a comma delimited list of Groovy profile versions to install.

Signed-off-by: Northard, Robert A <robert.a.northard@accenture.com>