### PR TITLE
Load_Platform: Using ADOP_PLATFORM_MANAGEMENT_VERSION if specified

### DIFF
--- a/resources/jobs/Load_Platform/config.xml
+++ b/resources/jobs/Load_Platform/config.xml
@@ -23,6 +23,16 @@
       </parameterDefinitions>
     </hudson.model.ParametersDefinitionProperty>
     <de.pellepelster.jenkins.walldisplay.WallDisplayJobProperty plugin="jenkinswalldisplay@0.6.30"/>
+    <EnvInjectJobProperty plugin="envinject@1.92.1">
+      <info>
+        <loadFilesFromMaster>false</loadFilesFromMaster>
+      </info>
+      <on>true</on>
+      <keepJenkinsSystemVariables>true</keepJenkinsSystemVariables>
+      <keepBuildVariables>true</keepBuildVariables>
+      <overrideBuildParameters>false</overrideBuildParameters>
+      <contributors/>
+    </EnvInjectJobProperty>
   </properties>
   <scm class="hudson.plugins.git.GitSCM" plugin="git@3.0.0">
     <configVersion>2</configVersion>
@@ -81,7 +91,15 @@ fi
 # Setup remote &amp; populate
 git remote add adop ssh://jenkins@gerrit:29418/&quot;${target_repo_name}&quot;
 git fetch adop
-git push adop +refs/remotes/origin/*:refs/heads/*</command>
+git push adop +refs/remotes/origin/*:refs/heads/*
+
+# If a version has been specified, let&apos;s switch to it
+if [ ! -z &quot;${ADOP_PLATFORM_MANAGEMENT_VERSION}&quot; ] &amp;&amp; [[ &quot;${ADOP_PLATFORM_MANAGEMENT_VERSION}&quot; =~ ^[a-fA-F0-9]{8,40}$ ]] &amp;&amp; [ &quot;$(git cat-file -t &quot;${ADOP_PLATFORM_MANAGEMENT_VERSION}&quot;)&quot; = &quot;commit&quot; ]; then
+	echo &quot;INFO - Checking out specified ADOP_PLATFORM_MANAGEMENT_VERSION &apos;${ADOP_PLATFORM_MANAGEMENT_VERSION}&apos;&quot;
+    git checkout &quot;${ADOP_PLATFORM_MANAGEMENT_VERSION}&quot;
+else
+	echo &quot;WARNING - ADOP_PLATFORM_MANAGEMENT_VERSION is set to &apos;${ADOP_PLATFORM_MANAGEMENT_VERSION}&apos; which is not a valid Git commit hash - defaulting to &apos;master&apos;&quot;
+fi</command>
     </hudson.tasks.Shell>
     <javaposse.jobdsl.plugin.ExecuteDslScripts plugin="job-dsl@1.48">
       <targets>bootstrap/**/*.groovy</targets>


### PR DESCRIPTION
This PR enables Load_Platform to use the value of ADOP_PLATFORM_MANAGEMENT_VERSION if specified in Jenkins. This is part of Accenture/adop-platform-management#11 and maintains the current behaviour of using master (as defined in the SCM section) if the value is not provided or invalid in some way for backwards compatibility.

It follows the same rules as Accenture/adop-platform-management#11 in that it only allows a valid Git commit ID, although it goes further in that it tests if it is actually present in the repository.

I'll create the adop-docker-compose PR once the release exists.