### PR TITLE
Add env variable to check if ldap is external or internal. Default is internal.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ENV GERRIT_PORT 8080
 ENV GERRIT_SSH_PORT 29418
 ENV GERRIT_PROFILE="ADOP Gerrit" GERRIT_JENKINS_USERNAME="" GERRIT_JENKINS_PASSWORD=""
 
-
 # Copy in configuration files
 COPY resources/plugins.txt /usr/share/jenkins/ref/
 COPY resources/init.groovy.d/ /usr/share/jenkins/ref/init.groovy.d/
@@ -25,7 +24,7 @@ RUN chmod +x -R /usr/share/jenkins/ref/adop_scripts/ && chmod +x /entrypoint.sh
 # USER jenkins
 
 # Environment variables
-ENV ADOP_LDAP_ENABLED=true ADOP_ACL_ENABLED=true ADOP_SONAR_ENABLED=true ADOP_ANT_ENABLED=true ADOP_MAVEN_ENABLED=true ADOP_NODEJS_ENABLED=true ADOP_GERRIT_ENABLED=true
+ENV ADOP_LDAP_ENABLED=true LDAP_IS_MODIFIABLE=true ADOP_ACL_ENABLED=true ADOP_SONAR_ENABLED=true ADOP_ANT_ENABLED=true ADOP_MAVEN_ENABLED=true ADOP_NODEJS_ENABLED=true ADOP_GERRIT_ENABLED=true
 ENV LDAP_GROUP_NAME_ADMIN=""
 ENV JENKINS_OPTS="--prefix=/jenkins -Djenkins.install.runSetupWizard=false"
 ENV PLUGGABLE_SCM_PROVIDER_PROPERTIES_PATH="/var/jenkins_home/userContent/datastore/pluggable/scm"

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Additional environment variables that allow fine tune Jenkins runtime configurat
 * DOCKER_CERT_PATH, Docker CLI variable to declare the path to the certificate
 * DOCKER_NETWORK_NAME, the Docker custom network to launch containers on
 * GROOVY_VERSION, a comma delimited list of Groovy installation profiles to install (e.g. 2.4.8, 2.4.3).
+* LDAP_IS_MODIFIABLE, allows us to interact with LDAP configuration through jenkins, Allowed values true (default) and false. If set to true, LDAP can be modified and jenkins will be able to create necessary users/groups in LDAP. If set to false, LDAP can not be modified and jenkins need be configured to use existing users/groups in LDAP. This variable will be used when ADOP_LDAP_ENABLED is set to true.
 
 ## Run adop-jenkins with OpenLDAP
 The following assumes that MySQL and OpenLDAP are running.

--- a/resources/init.groovy.d/adop_general.groovy
+++ b/resources/init.groovy.d/adop_general.groovy
@@ -26,6 +26,7 @@ def scmProviderPropertiesPath = env['PLUGGABLE_SCM_PROVIDER_PROPERTIES_PATH']
 def scmProviderPluggablePath = env['PLUGGABLE_SCM_PROVIDER_PATH']
 def adopLdapEnabled = env['ADOP_LDAP_ENABLED']
 def adopAclEnabled = env['ADOP_ACL_ENABLED']
+def ldapIsModifiable = env['LDAP_IS_MODIFIABLE']
 
 def cartridgeSources = env['CARTRIDGE_SOURCES']
 
@@ -120,6 +121,10 @@ Thread.start {
 
     if ( adopAclEnabled != null ) {
         envVars.put("ADOP_ACL_ENABLED", adopAclEnabled)
+    }
+
+    if (ldapIsModifiable != null ) {
+        envVars.put("LDAP_IS_MODIFIABLE", ldapIsModifiable)
     }
 
     // Jenkins SSH Credentials


### PR DESCRIPTION
Added "ENABLE_INTERNAL_LDAP" environment variable which tells what LDAP connection we have (external or internal). This environment variable is used in [adop-platform-managment](https://github.com/Accenture/adop-platform-management/pull/50) repository. 