### PR TITLE
Updated Jenkins key exchange algorithms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,6 @@ ENV PLUGGABLE_SCM_PROVIDER_PROPERTIES_PATH="/var/jenkins_home/userContent/datast
 ENV PLUGGABLE_SCM_PROVIDER_PATH="/var/jenkins_home/userContent/job_dsl_additional_classpath/"
 
 RUN xargs /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
-RUN echo "KexAlgorithms diffie-hellman-group1-sha1" >> /etc/ssh/ssh_config
+RUN echo "KexAlgorithms curve25519-sha256@libssh.org,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group14-sha256,diffie-hellman-group1-sha1" >> /etc/ssh/ssh_config
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
The new Ciphers are required for SSH cloning from Gitlab on Jenkins jobs